### PR TITLE
Rename `StreamError` to `Error`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ dependencies {
 This is a basic model to represent a normalized result from business work. This looks similar to [Kotlin's Result](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result/), but Stream Result was designed to include more information about success and error and support more convenient functionalities to handle results. Result is basically consist of two detailed types below:
 
 - **Result.Success**: This represents your business's successful result, including a `value` property, a generic type of Result.
-- **Result.Failure**: This represents the failed result of your business result and includes a `value` property, the `StreamError` type.
+- **Result.Failure**: This represents the failed result of your business result and includes a `value` property, the `Error` type.
 
 You can simply create each instance of `Result` like the example below:
 
@@ -60,7 +60,7 @@ You can simply create each instance of `Result` like the example below:
 val result0: Result<String> = Result.Success(value = "result")
 
 val result1: Result<String> = Result.Failure(
-  value = StreamError.GenericError(message = "failure")
+  value = Error.GenericError(message = "failure")
 )
 
 val result = result0 then { result1 }
@@ -71,31 +71,31 @@ result.onSuccess {
 }
 ```
 
-## StreamError
+## Error
 
-`Result.Failure` has `StreamError` as a value property, which contains error details of your business work. Basically, `StreamError` consists of three different types of errors below:
+`Result.Failure` has `Error` as a value property, which contains error details of your business work. Basically, `Error` consists of three different types of errors below:
 
-- **StreamError.GenericError**: Represents a normal type of error and only contains an error message.
-- **StreamError.ThrowableError**: Represents an exceptional type of error and contains a message and cause information.
-- **StreamError.NetworkError**: Represents a network error and contains status code, message, and cause information.
+- **Error.GenericError**: Represents a normal type of error and only contains an error message.
+- **Error.ThrowableError**: Represents an exceptional type of error and contains a message and cause information.
+- **Error.NetworkError**: Represents a network error and contains status code, message, and cause information.
 
 You can create each instance like the example below:
 
 ```kotlin
-val streamError: StreamError = StreamError.GenericError(message = "error")
+val error: Error = Error.GenericError(message = "error")
 
 try {
      .. 
 } catch (e: Exception) {
-  val streamError: StreamError = StreamError.ThrowableError(
+  val error: Error = Error.ThrowableError(
     message = e.localizedMessage ?: e.stackTraceToString(), 
     cause = e
   )
 }
 
-val streamError: StreamError = StreamError.NetworkError(
+val error: Error = Error.NetworkError(
   message = "error",
-  streamCode = code,
+  serverErrorCode = code,
   statusCode = statusCode
 )
 ```
@@ -268,9 +268,9 @@ Retry a network request following your `RetryPolicy`.
 
 ```kotlin
 private val retryPolicy = object : RetryPolicy {
-  override fun shouldRetry(attempt: Int, error: StreamError): Boolean = attempt <= 3
+  override fun shouldRetry(attempt: Int, error: Error): Boolean = attempt <= 3
 
-  override fun retryTimeout(attempt: Int, error: StreamError): Int = 3000
+  override fun retryTimeout(attempt: Int, error: Error): Int = 3000
 }
 
 
@@ -282,7 +282,7 @@ val result = posterService.fetchPosterList()
 
 ### Custom Error Parser
 
-You can customize the creating of `StreamError` from an error response according to your backend service by implementing your `ErrorParser` class. You can provide your custom `ErrorParser` to `RetrofitCallAdapterFactory`. If not, it will use a default `ErrorParser`, which uses [Kotlin Serialization](https://kotlinlang.org/docs/serialization.html) to decode json formats.
+You can customize the creating of `Error` from an error response according to your backend service by implementing your `ErrorParser` class. You can provide your custom `ErrorParser` to `RetrofitCallAdapterFactory`. If not, it will use a default `ErrorParser`, which uses [Kotlin Serialization](https://kotlinlang.org/docs/serialization.html) to decode json formats.
 
 ```kotlin
 internal class MyErrorParser : ErrorParser<DefaultErrorResponse> {
@@ -292,12 +292,12 @@ internal class MyErrorParser : ErrorParser<DefaultErrorResponse> {
     // use moshi or something that you can serialize from json response.
   }
 
-  override fun toError(okHttpResponse: Response): StreamError {
-    // build StreamError with a given okHttpResponse.
+  override fun toError(okHttpResponse: Response): Error {
+    // build Error with a given okHttpResponse.
   }
 
-  override fun toError(errorResponseBody: ResponseBody): StreamError {
-    // build StreamError with a given errorResponseBody.
+  override fun toError(errorResponseBody: ResponseBody): Error {
+    // build Error with a given errorResponseBody.
   }
 }
 

--- a/app/src/main/kotlin/io/getstream/resultdemo/MainViewModel.kt
+++ b/app/src/main/kotlin/io/getstream/resultdemo/MainViewModel.kt
@@ -19,7 +19,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.getstream.log.StreamLog
 import io.getstream.log.streamLog
-import io.getstream.result.StreamError
+import io.getstream.result.Error
 import io.getstream.result.call.doOnResult
 import io.getstream.result.call.doOnStart
 import io.getstream.result.call.map
@@ -60,8 +60,8 @@ public class MainViewModel constructor(
   }
 
   private val retryPolicy = object : RetryPolicy {
-    override fun shouldRetry(attempt: Int, error: StreamError): Boolean = attempt <= 3
+    override fun shouldRetry(attempt: Int, error: Error): Boolean = attempt <= 3
 
-    override fun retryTimeout(attempt: Int, error: StreamError): Int = 3000
+    override fun retryTimeout(attempt: Int, error: Error): Int = 3000
   }
 }

--- a/stream-result-call-retrofit/api/stream-result-call-retrofit.api
+++ b/stream-result-call-retrofit/api/stream-result-call-retrofit.api
@@ -1,12 +1,12 @@
 public abstract interface class io/getstream/result/call/retrofit/ErrorParser {
 	public abstract fun fromJson (Ljava/lang/String;)Ljava/lang/Object;
-	public abstract fun toError (Lokhttp3/Response;)Lio/getstream/result/StreamError;
-	public abstract fun toError (Lokhttp3/ResponseBody;)Lio/getstream/result/StreamError;
+	public abstract fun toError (Lokhttp3/Response;)Lio/getstream/result/Error;
+	public abstract fun toError (Lokhttp3/ResponseBody;)Lio/getstream/result/Error;
 }
 
 public final class io/getstream/result/call/retrofit/ErrorParser$DefaultImpls {
-	public static fun toError (Lio/getstream/result/call/retrofit/ErrorParser;Lokhttp3/Response;)Lio/getstream/result/StreamError;
-	public static fun toError (Lio/getstream/result/call/retrofit/ErrorParser;Lokhttp3/ResponseBody;)Lio/getstream/result/StreamError;
+	public static fun toError (Lio/getstream/result/call/retrofit/ErrorParser;Lokhttp3/Response;)Lio/getstream/result/Error;
+	public static fun toError (Lio/getstream/result/call/retrofit/ErrorParser;Lokhttp3/ResponseBody;)Lio/getstream/result/Error;
 }
 
 public final class io/getstream/result/call/retrofit/RetrofitCall : io/getstream/result/call/Call {

--- a/stream-result-call-retrofit/src/main/kotlin/io/getstream/result/call/retrofit/ErrorParser.kt
+++ b/stream-result-call-retrofit/src/main/kotlin/io/getstream/result/call/retrofit/ErrorParser.kt
@@ -15,7 +15,7 @@
  */
 package io.getstream.result.call.retrofit
 
-import io.getstream.result.StreamError
+import io.getstream.result.Error
 import okhttp3.Response
 import okhttp3.ResponseBody
 
@@ -23,7 +23,7 @@ public interface ErrorParser<T> {
 
   public fun <T : Any> fromJson(raw: String): T
 
-  public fun toError(okHttpResponse: Response): StreamError {
+  public fun toError(okHttpResponse: Response): Error {
     val statusCode: Int = okHttpResponse.code
 
     return try {
@@ -31,38 +31,38 @@ public interface ErrorParser<T> {
       val body = okHttpResponse.peekBody(Long.MAX_VALUE).string()
 
       if (body.isEmpty()) {
-        StreamError.NetworkError(
+        Error.NetworkError(
           message = okHttpResponse.message,
-          streamCode = statusCode,
+          serverErrorCode = statusCode,
           statusCode = statusCode
         )
       } else {
-        StreamError.NetworkError(
-          streamCode = statusCode,
+        Error.NetworkError(
           message = okHttpResponse.message,
+          serverErrorCode = statusCode,
           statusCode = statusCode
         )
       }
     } catch (expected: Throwable) {
-      StreamError.ThrowableError(
+      Error.ThrowableError(
         message = expected.message ?: expected.stackTraceToString(),
         cause = expected
       )
     }
   }
 
-  public fun toError(errorResponseBody: ResponseBody): StreamError {
+  public fun toError(errorResponseBody: ResponseBody): Error {
     return try {
       val errorResponse: DefaultErrorResponse = fromJson(errorResponseBody.string())
       val (code, message, statusCode) = errorResponse
 
-      StreamError.NetworkError(
-        streamCode = code,
+      Error.NetworkError(
+        serverErrorCode = code,
         message = message,
         statusCode = statusCode
       )
     } catch (expected: Throwable) {
-      StreamError.ThrowableError(
+      Error.ThrowableError(
         message = expected.message ?: expected.stackTraceToString(),
         cause = expected
       )

--- a/stream-result-call-retrofit/src/main/kotlin/io/getstream/result/call/retrofit/RetrofitCall.kt
+++ b/stream-result-call-retrofit/src/main/kotlin/io/getstream/result/call/retrofit/RetrofitCall.kt
@@ -15,8 +15,8 @@
  */
 package io.getstream.result.call.retrofit
 
+import io.getstream.result.Error
 import io.getstream.result.Result
-import io.getstream.result.StreamError
 import io.getstream.result.call.Call
 import io.getstream.result.call.dispatcher.CallDispatcherProvider
 import kotlinx.coroutines.CoroutineScope
@@ -65,7 +65,7 @@ public class RetrofitCall<T : Any>(
 
   private fun Throwable.toFailedError(
     message: String
-  ): StreamError = StreamError.ThrowableError(cause = this, message = message)
+  ): Error = Error.ThrowableError(cause = this, message = message)
 
   @Suppress("TooGenericExceptionCaught")
   private suspend fun retrofit2.Call<T>.getResult(): Result<T> =

--- a/stream-result-call/api/stream-result-call.api
+++ b/stream-result-call/api/stream-result-call.api
@@ -88,7 +88,7 @@ public final class io/getstream/result/call/dispatcher/CallDispatcherProvider {
 }
 
 public abstract interface class io/getstream/result/call/retry/RetryPolicy {
-	public abstract fun retryTimeout (ILio/getstream/result/StreamError;)I
-	public abstract fun shouldRetry (ILio/getstream/result/StreamError;)Z
+	public abstract fun retryTimeout (ILio/getstream/result/Error;)I
+	public abstract fun shouldRetry (ILio/getstream/result/Error;)Z
 }
 

--- a/stream-result-call/src/main/kotlin/io/getstream/result/call/Call.kt
+++ b/stream-result-call/src/main/kotlin/io/getstream/result/call/Call.kt
@@ -15,8 +15,8 @@
  */
 package io.getstream.result.call
 
+import io.getstream.result.Error
 import io.getstream.result.Result
-import io.getstream.result.StreamError
 import io.getstream.result.call.retry.CallRetryService
 import io.getstream.result.call.retry.RetryCall
 import io.getstream.result.call.retry.RetryPolicy
@@ -76,7 +76,7 @@ public interface Call<T : Any> {
 
   public companion object {
     public fun <T : Any> callCanceledError(): Result<T> =
-      Result.Failure(StreamError.GenericError(message = "The call was canceled before complete its execution."))
+      Result.Failure(Error.GenericError(message = "The call was canceled before complete its execution."))
 
     @SuppressWarnings("TooGenericExceptionCaught")
     public suspend fun <T : Any> runCatching(
@@ -90,7 +90,7 @@ public interface Call<T : Any> {
 
     private fun <T : Any> Throwable.toResult(): Result<T> = when (this) {
       is CancellationException -> callCanceledError()
-      else -> Result.Failure(StreamError.ThrowableError(message = "", cause = this))
+      else -> Result.Failure(Error.ThrowableError(message = "", cause = this))
     }
   }
 }
@@ -169,7 +169,7 @@ public fun <T : Any> Call<T>.withPrecondition(
  */
 public fun <T : Any> Call<T>.onErrorReturn(
   scope: CoroutineScope,
-  function: suspend (originalError: StreamError) -> Result<T>
+  function: suspend (originalError: Error) -> Result<T>
 ): ReturnOnErrorCall<T> = ReturnOnErrorCall(this, scope, function)
 
 /**
@@ -186,11 +186,11 @@ public fun <T : Any> Call<T>.share(
 public fun Call<*>.toUnitCall(): Call<Unit> = map {}
 
 private val onSuccessStub: (Any) -> Unit = {}
-private val onErrorStub: (StreamError) -> Unit = {}
+private val onErrorStub: (Error) -> Unit = {}
 
 public fun <T : Any> Call<T>.enqueue(
   onSuccess: (T) -> Unit = onSuccessStub,
-  onError: (StreamError) -> Unit = onErrorStub
+  onError: (Error) -> Unit = onErrorStub
 ) {
   enqueue { result ->
     when (result) {

--- a/stream-result-call/src/main/kotlin/io/getstream/result/call/ErrorCall.kt
+++ b/stream-result-call/src/main/kotlin/io/getstream/result/call/ErrorCall.kt
@@ -15,8 +15,8 @@
  */
 package io.getstream.result.call
 
+import io.getstream.result.Error
 import io.getstream.result.Result
-import io.getstream.result.StreamError
 import io.getstream.result.call.dispatcher.CallDispatcherProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -24,7 +24,7 @@ import kotlinx.coroutines.withContext
 
 internal class ErrorCall<T : Any>(
   private val scope: CoroutineScope,
-  private val e: StreamError
+  private val e: Error
 ) : Call<T> {
   override fun cancel() {
     // Not supported

--- a/stream-result-call/src/main/kotlin/io/getstream/result/call/ReturnOnErrorCall.kt
+++ b/stream-result-call/src/main/kotlin/io/getstream/result/call/ReturnOnErrorCall.kt
@@ -15,8 +15,8 @@
  */
 package io.getstream.result.call
 
+import io.getstream.result.Error
 import io.getstream.result.Result
-import io.getstream.result.StreamError
 import io.getstream.result.call.dispatcher.CallDispatcherProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -33,7 +33,7 @@ import kotlinx.coroutines.withContext
 public class ReturnOnErrorCall<T : Any>(
   private val originalCall: Call<T>,
   scope: CoroutineScope,
-  private val onErrorReturn: suspend (originalError: StreamError) -> Result<T>
+  private val onErrorReturn: suspend (originalError: Error) -> Result<T>
 ) : Call<T> {
 
   private val callScope = scope + SupervisorJob(scope.coroutineContext.job)

--- a/stream-result-call/src/main/kotlin/io/getstream/result/call/ZipCall.kt
+++ b/stream-result-call/src/main/kotlin/io/getstream/result/call/ZipCall.kt
@@ -15,8 +15,8 @@
  */
 package io.getstream.result.call
 
+import io.getstream.result.Error
 import io.getstream.result.Result
-import io.getstream.result.StreamError
 import io.getstream.result.call.dispatcher.CallDispatcherProvider
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
@@ -67,7 +67,7 @@ internal class ZipCall<A : Any, B : Any>(
     return if (this is Result.Success && result is Result.Success) {
       Result.Success(Pair(this.value, result.value))
     } else {
-      Result.Failure(StreamError.GenericError("Cannot combine results because one of them failed."))
+      Result.Failure(Error.GenericError("Cannot combine results because one of them failed."))
     }
   }
 

--- a/stream-result-call/src/main/kotlin/io/getstream/result/call/retry/CallRetryService.kt
+++ b/stream-result-call/src/main/kotlin/io/getstream/result/call/retry/CallRetryService.kt
@@ -16,8 +16,8 @@
 package io.getstream.result.call.retry
 
 import io.getstream.log.taggedLogger
+import io.getstream.result.Error
 import io.getstream.result.Result
-import io.getstream.result.StreamError
 import kotlinx.coroutines.delay
 
 /**
@@ -27,7 +27,7 @@ import kotlinx.coroutines.delay
  */
 internal class CallRetryService(
   private val retryPolicy: RetryPolicy,
-  private val isPermanent: (StreamError) -> Boolean = { false }
+  private val isPermanent: (Error) -> Boolean = { false }
 ) {
 
   private val logger by taggedLogger("CallRetryService")

--- a/stream-result-call/src/main/kotlin/io/getstream/result/call/retry/RetryPolicy.kt
+++ b/stream-result-call/src/main/kotlin/io/getstream/result/call/retry/RetryPolicy.kt
@@ -15,7 +15,7 @@
  */
 package io.getstream.result.call.retry
 
-import io.getstream.result.StreamError
+import io.getstream.result.Error
 
 /**
  * The retry policy is being used to determine if and when the call should be retried if a temporary error occurred.
@@ -29,7 +29,7 @@ public interface RetryPolicy {
    *
    * @return true if the call should be retried, false otherwise.
    */
-  public fun shouldRetry(attempt: Int, error: StreamError): Boolean
+  public fun shouldRetry(attempt: Int, error: Error): Boolean
 
   /**
    * Provides a timeout used to delay the next call.
@@ -39,5 +39,5 @@ public interface RetryPolicy {
    *
    * @return The timeout in milliseconds before making a retry.
    */
-  public fun retryTimeout(attempt: Int, error: StreamError): Int
+  public fun retryTimeout(attempt: Int, error: Error): Int
 }

--- a/stream-result/api/stream-result.api
+++ b/stream-result/api/stream-result.api
@@ -1,4 +1,61 @@
+public abstract class io/getstream/result/Error {
+	public abstract fun getMessage ()Ljava/lang/String;
+}
+
+public final class io/getstream/result/Error$GenericError : io/getstream/result/Error {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/result/Error$GenericError;
+	public static synthetic fun copy$default (Lio/getstream/result/Error$GenericError;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/result/Error$GenericError;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/result/Error$NetworkError : io/getstream/result/Error {
+	public static final field Companion Lio/getstream/result/Error$NetworkError$Companion;
+	public static final field UNKNOWN_STATUS_CODE I
+	public fun <init> (Ljava/lang/String;IILjava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;IILjava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/String;IILjava/lang/Throwable;)Lio/getstream/result/Error$NetworkError;
+	public static synthetic fun copy$default (Lio/getstream/result/Error$NetworkError;Ljava/lang/String;IILjava/lang/Throwable;ILjava/lang/Object;)Lio/getstream/result/Error$NetworkError;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCause ()Ljava/lang/Throwable;
+	public fun getMessage ()Ljava/lang/String;
+	public final fun getServerErrorCode ()I
+	public final fun getStatusCode ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/result/Error$NetworkError$Companion {
+}
+
+public final class io/getstream/result/Error$ThrowableError : io/getstream/result/Error {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Throwable;)Lio/getstream/result/Error$ThrowableError;
+	public static synthetic fun copy$default (Lio/getstream/result/Error$ThrowableError;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)Lio/getstream/result/Error$ThrowableError;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCause ()Ljava/lang/Throwable;
+	public fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/result/ErrorKt {
+	public static final fun copyWithMessage (Lio/getstream/result/Error;Ljava/lang/String;)Lio/getstream/result/Error;
+	public static final fun extractCause (Lio/getstream/result/Error;)Ljava/lang/Throwable;
+}
+
 public abstract class io/getstream/result/Result {
+	public final fun errorOrNull ()Lio/getstream/result/Error;
 	public final fun getOrNull ()Ljava/lang/Object;
 	public final fun getOrThrow ()Ljava/lang/Object;
 	public final fun isFailure ()Z
@@ -7,17 +64,16 @@ public abstract class io/getstream/result/Result {
 	public final synthetic fun mapSuspend (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun onError (Lkotlin/jvm/functions/Function1;)Lio/getstream/result/Result;
 	public final fun onSuccess (Lkotlin/jvm/functions/Function1;)Lio/getstream/result/Result;
-	public final fun streamErrorOrNull ()Lio/getstream/result/StreamError;
 	public final fun toUnitResult ()Lio/getstream/result/Result;
 }
 
 public final class io/getstream/result/Result$Failure : io/getstream/result/Result {
-	public fun <init> (Lio/getstream/result/StreamError;)V
-	public final fun component1 ()Lio/getstream/result/StreamError;
-	public final fun copy (Lio/getstream/result/StreamError;)Lio/getstream/result/Result$Failure;
-	public static synthetic fun copy$default (Lio/getstream/result/Result$Failure;Lio/getstream/result/StreamError;ILjava/lang/Object;)Lio/getstream/result/Result$Failure;
+	public fun <init> (Lio/getstream/result/Error;)V
+	public final fun component1 ()Lio/getstream/result/Error;
+	public final fun copy (Lio/getstream/result/Error;)Lio/getstream/result/Result$Failure;
+	public static synthetic fun copy$default (Lio/getstream/result/Result$Failure;Lio/getstream/result/Error;ILjava/lang/Object;)Lio/getstream/result/Result$Failure;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getValue ()Lio/getstream/result/StreamError;
+	public final fun getValue ()Lio/getstream/result/Error;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -41,62 +97,6 @@ public final class io/getstream/result/ResultKt {
 	public static final synthetic fun recover (Lio/getstream/result/Result;Lkotlin/jvm/functions/Function1;)Lio/getstream/result/Result$Success;
 	public static final synthetic fun recoverSuspend (Lio/getstream/result/Result;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final synthetic fun then (Lio/getstream/result/Result;Lkotlin/jvm/functions/Function1;)Lio/getstream/result/Result;
-}
-
-public abstract class io/getstream/result/StreamError {
-	public abstract fun getMessage ()Ljava/lang/String;
-}
-
-public final class io/getstream/result/StreamError$GenericError : io/getstream/result/StreamError {
-	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lio/getstream/result/StreamError$GenericError;
-	public static synthetic fun copy$default (Lio/getstream/result/StreamError$GenericError;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/result/StreamError$GenericError;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getMessage ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class io/getstream/result/StreamError$NetworkError : io/getstream/result/StreamError {
-	public static final field Companion Lio/getstream/result/StreamError$NetworkError$Companion;
-	public static final field UNKNOWN_STATUS_CODE I
-	public fun <init> (Ljava/lang/String;IILjava/lang/Throwable;)V
-	public synthetic fun <init> (Ljava/lang/String;IILjava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()I
-	public final fun component3 ()I
-	public final fun component4 ()Ljava/lang/Throwable;
-	public final fun copy (Ljava/lang/String;IILjava/lang/Throwable;)Lio/getstream/result/StreamError$NetworkError;
-	public static synthetic fun copy$default (Lio/getstream/result/StreamError$NetworkError;Ljava/lang/String;IILjava/lang/Throwable;ILjava/lang/Object;)Lio/getstream/result/StreamError$NetworkError;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCause ()Ljava/lang/Throwable;
-	public fun getMessage ()Ljava/lang/String;
-	public final fun getStatusCode ()I
-	public final fun getStreamCode ()I
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class io/getstream/result/StreamError$NetworkError$Companion {
-}
-
-public final class io/getstream/result/StreamError$ThrowableError : io/getstream/result/StreamError {
-	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/Throwable;
-	public final fun copy (Ljava/lang/String;Ljava/lang/Throwable;)Lio/getstream/result/StreamError$ThrowableError;
-	public static synthetic fun copy$default (Lio/getstream/result/StreamError$ThrowableError;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)Lio/getstream/result/StreamError$ThrowableError;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCause ()Ljava/lang/Throwable;
-	public fun getMessage ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class io/getstream/result/StreamErrorKt {
-	public static final fun copyWithMessage (Lio/getstream/result/StreamError;Ljava/lang/String;)Lio/getstream/result/StreamError;
-	public static final fun extractCause (Lio/getstream/result/StreamError;)Ljava/lang/Throwable;
 }
 
 public abstract interface annotation class io/getstream/result/internal/StreamHandsOff : java/lang/annotation/Annotation {

--- a/stream-result/src/main/kotlin/io/getstream/result/Error.kt
+++ b/stream-result/src/main/kotlin/io/getstream/result/Error.kt
@@ -15,13 +15,13 @@
  */
 package io.getstream.result
 
-import io.getstream.result.StreamError.NetworkError.Companion.UNKNOWN_STATUS_CODE
+import io.getstream.result.Error.NetworkError.Companion.UNKNOWN_STATUS_CODE
 import io.getstream.result.internal.StreamHandsOff
 
 /**
  * Represents the generic error model.
  */
-public sealed class StreamError {
+public sealed class Error {
 
   public abstract val message: String
 
@@ -30,7 +30,7 @@ public sealed class StreamError {
    *
    * @param message The message describing the error.
    */
-  public data class GenericError(override val message: String) : StreamError()
+  public data class GenericError(override val message: String) : Error()
 
   /**
    * An error that contains a message and cause.
@@ -39,7 +39,7 @@ public sealed class StreamError {
    * @param cause The [Throwable] associated with the error.
    */
   public data class ThrowableError(override val message: String, public val cause: Throwable) :
-    StreamError() {
+    Error() {
 
     @StreamHandsOff(
       "Throwable doesn't override the equals method;" +
@@ -49,7 +49,7 @@ public sealed class StreamError {
       if (this === other) return true
       if (javaClass != other?.javaClass) return false
 
-      return (other as? StreamError)?.let {
+      return (other as? Error)?.let {
         message == it.message && cause.equalCause(it.extractCause())
       } ?: false
     }
@@ -72,16 +72,16 @@ public sealed class StreamError {
    * An error resulting from the network operation.
    *
    * @param message The message describing the error.
-   * @param streamCode The code returned by the Stream backend.
+   * @param serverErrorCode The error code returned by the backend.
    * @param statusCode HTTP status code or [UNKNOWN_STATUS_CODE] if not available.
    * @param cause The optional [Throwable] associated with the error.
    */
   public data class NetworkError(
     override val message: String,
-    public val streamCode: Int,
+    public val serverErrorCode: Int,
     public val statusCode: Int = UNKNOWN_STATUS_CODE,
     public val cause: Throwable? = null
-  ) : StreamError() {
+  ) : Error() {
 
     @StreamHandsOff(
       "Throwable doesn't override the equals method;" +
@@ -91,7 +91,7 @@ public sealed class StreamError {
       if (this === other) return true
       if (javaClass != other?.javaClass) return false
 
-      return (other as? StreamError)?.let {
+      return (other as? Error)?.let {
         message == it.message && cause.equalCause(it.extractCause())
       } ?: false
     }
@@ -116,29 +116,29 @@ public sealed class StreamError {
 }
 
 /**
- * Copies the original [StreamError] objects with custom message.
+ * Copies the original [Error] objects with custom message.
  *
  * @param message The message to replace.
  *
- * @return New [StreamError] instance.
+ * @return New [Error] instance.
  */
-public fun StreamError.copyWithMessage(message: String): StreamError {
+public fun Error.copyWithMessage(message: String): Error {
   return when (this) {
-    is StreamError.GenericError -> this.copy(message = message)
-    is StreamError.NetworkError -> this.copy(message = message)
-    is StreamError.ThrowableError -> this.copy(message = message)
+    is Error.GenericError -> this.copy(message = message)
+    is Error.NetworkError -> this.copy(message = message)
+    is Error.ThrowableError -> this.copy(message = message)
   }
 }
 
 /**
- * Extracts the cause from [StreamError] object or null if it's not available.
+ * Extracts the cause from [Error] object or null if it's not available.
  *
  * @return The [Throwable] that is the error's cause or null if not available.
  */
-public fun StreamError.extractCause(): Throwable? {
+public fun Error.extractCause(): Throwable? {
   return when (this) {
-    is StreamError.GenericError -> null
-    is StreamError.NetworkError -> cause
-    is StreamError.ThrowableError -> cause
+    is Error.GenericError -> null
+    is Error.NetworkError -> cause
+    is Error.ThrowableError -> cause
   }
 }

--- a/stream-result/src/main/kotlin/io/getstream/result/Result.kt
+++ b/stream-result/src/main/kotlin/io/getstream/result/Result.kt
@@ -16,7 +16,7 @@
 package io.getstream.result
 
 /**
- *  A class which encapsulates a successful outcome with a value of type [A] or a failure with [StreamError].
+ *  A class which encapsulates a successful outcome with a value of type [A] or a failure with [Error].
  */
 public sealed class Result<out A : Any> {
 
@@ -52,10 +52,10 @@ public sealed class Result<out A : Any> {
   }
 
   /**
-   * Returns the encapsulated [StreamError] if this instance represents [Failure] [isFailure] or `null`
+   * Returns the encapsulated [Error] if this instance represents [Failure] [isFailure] or `null`
    * if it is [Success] [isSuccess].
    */
-  public fun streamErrorOrNull(): StreamError? = when (this) {
+  public fun errorOrNull(): Error? = when (this) {
     is Success -> null
     is Failure -> value
   }
@@ -70,9 +70,9 @@ public sealed class Result<out A : Any> {
   /**
    * Represents failed result.
    *
-   * @param value The [StreamError] associated with the result.
+   * @param value The [Error] associated with the result.
    */
-  public data class Failure(val value: StreamError) : Result<Nothing>()
+  public data class Failure(val value: Error) : Result<Nothing>()
 
   /**
    * Returns a transformed [Result] of applying the given [f] function if the [Result]
@@ -125,12 +125,12 @@ public sealed class Result<out A : Any> {
   /**
    * Runs the [errorSideEffect] lambda function if the [Result] contains an error payload.
    *
-   * @param errorSideEffect A lambda that receives the [StreamError] payload.
+   * @param errorSideEffect A lambda that receives the [Error] payload.
    *
    * @return The original instance of the [Result].
    */
   public inline fun onError(
-    crossinline errorSideEffect: (StreamError) -> Unit
+    crossinline errorSideEffect: (Error) -> Unit
   ): Result<A> =
     also {
       when (it) {
@@ -195,13 +195,13 @@ public suspend inline fun <A : Any> Result<A>.onSuccessSuspend(
 /**
  * Runs the suspending [errorSideEffect] lambda function if the [Result] contains an error payload.
  *
- * @param errorSideEffect A suspending lambda that receives the [StreamError] payload.
+ * @param errorSideEffect A suspending lambda that receives the [Error] payload.
  *
  * @return The original instance of the [Result].
  */
 @JvmSynthetic
 public suspend inline fun <A : Any> Result<A>.onErrorSuspend(
-  crossinline errorSideEffect: suspend (StreamError) -> Unit
+  crossinline errorSideEffect: suspend (Error) -> Unit
 ): Result<A> =
   also {
     when (it) {
@@ -214,13 +214,13 @@ public suspend inline fun <A : Any> Result<A>.onErrorSuspend(
  * Recovers the error payload by applying the given [errorMapper] function if the [Result]
  * contains an error payload.
  *
- * @param errorMapper A lambda that receives [StreamError] and transforms it as a payload [A].
- * @param errorMapper A lambda that receives [StreamError] and transforms it as a payload [A].
+ * @param errorMapper A lambda that receives [Error] and transforms it as a payload [A].
+ * @param errorMapper A lambda that receives [Error] and transforms it as a payload [A].
  *
  * @return A transformed instance of the [Result] or the original instance of the [Result].
  */
 @JvmSynthetic
-public fun <A : Any> Result<A>.recover(errorMapper: (StreamError) -> A): Result.Success<A> {
+public fun <A : Any> Result<A>.recover(errorMapper: (Error) -> A): Result.Success<A> {
   return when (this) {
     is Result.Success -> this
     is Result.Failure -> Result.Success(errorMapper(value))
@@ -231,13 +231,13 @@ public fun <A : Any> Result<A>.recover(errorMapper: (StreamError) -> A): Result.
  * Recovers the error payload by applying the given suspending [errorMapper] function if the [Result]
  * contains an error payload.
  *
- * @param errorMapper A suspending lambda that receives [StreamError] and transforms it as a payload [A].
+ * @param errorMapper A suspending lambda that receives [Error] and transforms it as a payload [A].
  *
  * @return A transformed instance of the [Result] or the original instance of the [Result].
  */
 @JvmSynthetic
 public suspend inline fun <A : Any> Result<A>.recoverSuspend(
-  crossinline errorMapper: suspend (StreamError) -> A
+  crossinline errorMapper: suspend (Error) -> A
 ): Result.Success<A> {
   return when (this) {
     is Result.Success -> this


### PR DESCRIPTION
### 🎯 Goal
Use a more generic name for the Error case. `StreamError` could be a confusing name for devs using this library

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMTJlNjIxZGEyM2MzZTYwOTFjOWYxMGI3OGVmOTMxYjIzNzBlNDMwOSZjdD1n/UV4liSdOaKdw3V9HGI/giphy.gif)
