### PR TITLE
Implement FlatMapCall

### DIFF
--- a/stream-result-call/api/stream-result-call.api
+++ b/stream-result-call/api/stream-result-call.api
@@ -26,6 +26,7 @@ public final class io/getstream/result/call/CallKt {
 	public static final fun doOnStart (Lio/getstream/result/call/Call;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Lio/getstream/result/call/Call;
 	public static final fun enqueue (Lio/getstream/result/call/Call;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun enqueue$default (Lio/getstream/result/call/Call;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun flatMap (Lio/getstream/result/call/Call;Lkotlin/jvm/functions/Function1;)Lio/getstream/result/call/Call;
 	public static final fun forceNewRequest (Lio/getstream/result/call/Call;)Lio/getstream/result/call/Call;
 	public static final fun launch (Lio/getstream/result/call/Call;Lkotlinx/coroutines/CoroutineScope;)V
 	public static final fun map (Lio/getstream/result/call/Call;Lkotlin/jvm/functions/Function1;)Lio/getstream/result/call/Call;

--- a/stream-result-call/src/main/kotlin/io/getstream/result/call/Call.kt
+++ b/stream-result-call/src/main/kotlin/io/getstream/result/call/Call.kt
@@ -116,6 +116,15 @@ public fun <T : Any, K : Any> Call<T>.map(mapper: (T) -> K): Call<K> {
 }
 
 /**
+ * Flat maps a [Call] type to a transformed [Call].
+ *
+ * @param mapper A lambda for mapping [T] to [Call] of [K].
+ */
+public fun <T : Any, K : Any> Call<T>.flatMap(mapper: (T) -> Call<K>): Call<K> {
+  return FlatMapCall(this, mapper)
+}
+
+/**
  * Zips a [Call] of [T] and a given [call] of [K].
  *
  * @param call [Call] to zip with the given [Call].

--- a/stream-result-call/src/main/kotlin/io/getstream/result/call/FlatMapCall.kt
+++ b/stream-result-call/src/main/kotlin/io/getstream/result/call/FlatMapCall.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getstream.result.call
+
+import io.getstream.result.Result
+import io.getstream.result.flatMapSuspend
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal class FlatMapCall<T : Any, K : Any>(
+  private val call: Call<T>,
+  private val mapper: (T) -> Call<K>
+) : Call<K> {
+  private val canceled = AtomicBoolean(false)
+  private var mappedCall: Call<K>? = null
+
+  override fun cancel() {
+    canceled.set(true)
+    call.cancel()
+    mappedCall?.cancel()
+  }
+
+  override fun execute(): Result<K> = runBlocking { await() }
+
+  override fun enqueue(callback: Call.Callback<K>) {
+    call.enqueue {
+      it.takeUnless { canceled.get() }
+        ?.onError { callback.onResult(Result.Failure(it)) }
+        ?.onSuccess { value ->
+          mapper(value)
+            .also { mappedCall = it }
+            .enqueue {
+              it.takeUnless { canceled.get() }?.let(callback::onResult)
+            }
+        }
+    }
+  }
+
+  override suspend fun await(): Result<K> =
+    call.await()
+      .takeUnless { canceled.get() }
+      ?.flatMapSuspend {
+        mapper(it)
+          .also { mappedCall = it }
+          .takeUnless { canceled.get() }
+          ?.await()
+          ?: Call.callCanceledError()
+      }
+      ?: Call.callCanceledError()
+}

--- a/stream-result-call/src/test/kotlin/io/getstream/result/call/FlatMapCallTest.kt
+++ b/stream-result-call/src/test/kotlin/io/getstream/result/call/FlatMapCallTest.kt
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getstream.result.call
+
+import io.getstream.result.Error
+import io.getstream.result.Result
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.only
+import org.mockito.kotlin.spy
+
+@ExtendWith(TestCoroutineExtension::class)
+internal class FlatMapCallTest {
+
+  private val resultValue = positiveRandomInt()
+  private val resultError = Error.GenericError(randomString())
+  private val validResult: Result<Int> = Result.Success(resultValue)
+  private val initCallErrorResult: Result<Int> = Result.Failure(resultError)
+  private val expectedResult: Result<String> = Result.Success("$resultValue")
+  private val expectedErrorResult: Result<String> = Result.Failure(resultError)
+  private val mapper: SpyMapper<Int, String> = SpyMapper { ResultCall(Result.Success("$it")) }
+  private val errorMapper: SpyMapper<Int, String> =
+    SpyMapper { ResultCall(Result.Failure(resultError)) }
+
+  @Test
+  fun `Call should be executed and return a valid result`() = runTest {
+    val blockedCall = BlockedCall(validResult).apply { unblock() }
+    val call = blockedCall.flatMap(mapper)
+
+    val result = call.execute()
+
+    result `should be equal to` expectedResult
+    mapper `should be invoked with` resultValue
+    blockedCall.isStarted() `should be equal to` true
+    blockedCall.isCompleted() `should be equal to` true
+    blockedCall.isCanceled() `should be equal to` false
+  }
+
+  @Test
+  fun `Mapped Call shouldn't be executed and error should be returned`() = runTest {
+    val blockedCall = BlockedCall(initCallErrorResult).apply { unblock() }
+    val call = blockedCall.flatMap(errorMapper)
+
+    val result = call.execute()
+
+    result `should be equal to` expectedErrorResult
+    errorMapper.`should not be invoked`()
+    blockedCall.isStarted() `should be equal to` true
+    blockedCall.isCompleted() `should be equal to` true
+    blockedCall.isCanceled() `should be equal to` false
+  }
+
+  @Test
+  fun `Call should be executed and return an error result`() = runTest {
+    val blockedCall = BlockedCall(validResult).apply { unblock() }
+    val call = blockedCall.flatMap(errorMapper)
+
+    val result = call.execute()
+
+    result `should be equal to` expectedErrorResult
+    errorMapper `should be invoked with` resultValue
+    blockedCall.isStarted() `should be equal to` true
+    blockedCall.isCompleted() `should be equal to` true
+    blockedCall.isCanceled() `should be equal to` false
+  }
+
+  @Test
+  fun `Canceled Call should be executed and return a cancel error`() = runTest {
+    val blockedCall = BlockedCall(validResult)
+    val call = blockedCall.flatMap(mapper)
+
+    val deferedResult = async { call.execute() }
+    call.cancel()
+    blockedCall.unblock()
+    val result = deferedResult.await()
+
+    result `should be equal to` Call.callCanceledError()
+    mapper.`should not be invoked`()
+    blockedCall.isStarted() `should be equal to` true
+    blockedCall.isCompleted() `should be equal to` false
+    blockedCall.isCanceled() `should be equal to` true
+  }
+
+  @Test
+  fun `Call should be enqueued and return a valid result by the callback`() = runTest {
+    val callback: Call.Callback<String> = mock()
+    val blockedCall = BlockedCall(validResult).apply { unblock() }
+    val call = blockedCall.flatMap(mapper)
+
+    call.enqueue(callback)
+
+    Mockito.verify(callback, only()).onResult(
+      org.mockito.kotlin.check {
+        it `should be equal to` expectedResult
+      }
+    )
+    mapper `should be invoked with` resultValue
+    blockedCall.isStarted() `should be equal to` true
+    blockedCall.isCompleted() `should be equal to` true
+    blockedCall.isCanceled() `should be equal to` false
+  }
+
+  @Test
+  fun `Mapped call shouldn't be enqueued and error should be returned by the callback`() = runTest {
+    val callback: Call.Callback<String> = mock()
+    val blockedCall = BlockedCall(initCallErrorResult).apply { unblock() }
+    val call = blockedCall.flatMap(errorMapper)
+
+    call.enqueue(callback)
+
+    Mockito.verify(callback, only()).onResult(
+      org.mockito.kotlin.check {
+        it `should be equal to` expectedErrorResult
+      }
+    )
+    errorMapper.`should not be invoked`()
+    blockedCall.isStarted() `should be equal to` true
+    blockedCall.isCompleted() `should be equal to` true
+    blockedCall.isCanceled() `should be equal to` false
+  }
+
+  @Test
+  fun `Call should be enqueued and return an error result by the callback`() = runTest {
+    val callback: Call.Callback<String> = mock()
+    val blockedCall = BlockedCall(validResult).apply { unblock() }
+    val call = blockedCall.flatMap(errorMapper)
+
+    call.enqueue(callback)
+
+    Mockito.verify(callback, only()).onResult(
+      org.mockito.kotlin.check {
+        it `should be equal to` expectedErrorResult
+      }
+    )
+    errorMapper `should be invoked with` resultValue
+    blockedCall.isStarted() `should be equal to` true
+    blockedCall.isCompleted() `should be equal to` true
+    blockedCall.isCanceled() `should be equal to` false
+  }
+
+  @Test
+  fun `Canceled Call should be enqueued and shouldn't return value on the callback`() = runTest {
+    val callback: Call.Callback<String> = spy()
+    val blockedCall = BlockedCall(validResult)
+    val call = blockedCall.flatMap(mapper)
+
+    call.enqueue(callback)
+    call.cancel()
+    blockedCall.unblock()
+
+    Mockito.verify(callback, never()).onResult(any())
+    mapper.`should not be invoked`()
+    blockedCall.isStarted() `should be equal to` true
+    blockedCall.isCompleted() `should be equal to` false
+    blockedCall.isCanceled() `should be equal to` true
+  }
+
+  @Test
+  fun `Call should be executed asynchronous and return a valid result`() = runTest {
+    val blockedCall = BlockedCall(validResult).apply { unblock() }
+    val call = blockedCall.flatMap(mapper)
+
+    val result = call.await()
+
+    result `should be equal to` expectedResult
+    mapper `should be invoked with` resultValue
+    blockedCall.isStarted() `should be equal to` true
+    blockedCall.isCompleted() `should be equal to` true
+    blockedCall.isCanceled() `should be equal to` false
+  }
+
+  @Test
+  fun `Canceled Call should be executed asynchronous and return a cancel error`() = runTest {
+    val blockedCall = BlockedCall(validResult)
+    val call = blockedCall.flatMap(mapper)
+
+    val deferedResult = async { call.await() }
+    call.cancel()
+    blockedCall.unblock()
+    val result = deferedResult.await()
+
+    result `should be equal to` Call.callCanceledError()
+    mapper.`should not be invoked`()
+    blockedCall.isStarted() `should be equal to` true
+    blockedCall.isCompleted() `should be equal to` false
+    blockedCall.isCanceled() `should be equal to` true
+  }
+
+  private class SpyMapper<T : Any, R : Any>(
+    private val mapFunction: (T) -> Call<R>
+  ) : (T) -> Call<R> {
+    private var invocations = 0
+    private var input: T? = null
+    override fun invoke(input: T): Call<R> {
+      invocations++
+      this.input = input
+      return mapFunction(input)
+    }
+
+    infix fun `should be invoked with`(input: T) {
+      invocations `should be equal to` 1
+      this.input `should be equal to` input
+    }
+
+    fun `should not be invoked`() {
+      if (invocations > 0) {
+        throw AssertionError("SpyMapper never wanted to be invoked but invoked")
+      }
+    }
+  }
+}

--- a/stream-result-call/src/test/kotlin/io/getstream/result/call/ResultCall.kt
+++ b/stream-result-call/src/test/kotlin/io/getstream/result/call/ResultCall.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getstream.result.call
+
+import io.getstream.result.Result
+
+internal class ResultCall<T : Any>(
+  private val result: Result<T>
+) : Call<T> {
+  override fun execute(): Result<T> = result
+  override suspend fun await(): Result<T> = result
+  override fun enqueue(callback: Call.Callback<T>) = callback.onResult(result)
+  override fun cancel() {
+    /* no-op */
+  }
+}


### PR DESCRIPTION
### 🎯 Goal
Implement `FlatMapCall`

It allows to concatenate multiple calls.
```
fun foo(): Call<Int> = [...]
fun bar(key: Int): Call<String> = [...]
val call: Call<String>  = foo().flatMap { bar(it) }
```

### 🎉 GIF

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNDhobTV0ZXBvdncyYXV4ZHpyemhwbGR4cmkzZW94NHZrcXJlZm82NyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l0MYvOjkBiEB0zjTq/giphy.gif)