### PR TITLE
Migrate to Stream Log 1.3.0 and support stream-result-call for KMP

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,5 +67,4 @@ dependencies {
 
   // logger
   implementation(libs.stream.log)
-  implementation(libs.stream.log.android)
 }

--- a/app/src/main/kotlin/io/getstream/resultdemo/StreamResultApp.kt
+++ b/app/src/main/kotlin/io/getstream/resultdemo/StreamResultApp.kt
@@ -16,7 +16,7 @@
 package io.getstream.resultdemo
 
 import android.app.Application
-import io.getstream.log.android.AndroidStreamLogger
+import io.getstream.log.AndroidStreamLogger
 
 class StreamResultApp : Application() {
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-streamLog = "1.1.4"
+streamLog = "1.3.1"
 androidGradlePlugin = "8.6.1"
 androidxActivity = "1.4.0"
 androidxAppCompat = "1.7.0"
@@ -31,7 +31,6 @@ mockitoKotlin = "4.1.0"
 
 [libraries]
 stream-log = { group = "io.getstream", name = "stream-log", version.ref = "streamLog" }
-stream-log-android = { group = "io.getstream", name = "stream-log-android", version.ref = "streamLog" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }
 androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "androidxAnnotation" }
 androidx-material = { module = "com.google.android.material:material", version.ref = "androidxMaterial" }

--- a/stream-result-call/build.gradle.kts
+++ b/stream-result-call/build.gradle.kts
@@ -40,18 +40,17 @@ mavenPublishing {
 }
 
 kotlin {
-  // TODO: Migrate Stream Log to KMP
-//  listOf(
-//    iosX64(),
-//    iosArm64(),
-//    iosSimulatorArm64(),
-//    macosArm64(),
-//    macosX64(),
-//  ).forEach {
-//    it.binaries.framework {
-//      baseName = "common"
-//    }
-//  }
+  listOf(
+    iosX64(),
+    iosArm64(),
+    iosSimulatorArm64(),
+    macosArm64(),
+    macosX64(),
+  ).forEach {
+    it.binaries.framework {
+      baseName = "common"
+    }
+  }
 
   androidTarget {
     publishLibraryVariants("release")
@@ -69,8 +68,12 @@ kotlin {
     all {
       languageSettings.optIn("kotlin.contracts.ExperimentalContracts")
     }
-    val commonMain by getting {
+    commonMain {
       dependencies {
+        api(project(":stream-result"))
+
+        implementation(libs.kotlinx.coroutines)
+        implementation(libs.stream.log)
       }
     }
   }
@@ -91,18 +94,13 @@ android {
     targetCompatibility = JavaVersion.VERSION_11
   }
 }
-
-dependencies {
-  api(project(":stream-result"))
-
-  implementation(libs.kotlinx.coroutines)
-  implementation(libs.stream.log)
-  testImplementation(libs.testing.kluent)
-  testImplementation(libs.testing.coroutines.test)
-  testImplementation(libs.testing.mockito)
-  testImplementation(libs.testing.mockito.kotlin)
-  testImplementation(libs.testing.mockito.kotlin)
-  testImplementation(libs.androidx.test.junit)
-  testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.0")
-  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.11.0")
-}
+ dependencies {
+   testImplementation(libs.testing.kluent)
+   testImplementation(libs.testing.coroutines.test)
+   testImplementation(libs.testing.mockito)
+   testImplementation(libs.testing.mockito.kotlin)
+   testImplementation(libs.testing.mockito.kotlin)
+   testImplementation(libs.androidx.test.junit)
+   testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.0")
+   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.11.0")
+ }

--- a/stream-result/build.gradle.kts
+++ b/stream-result/build.gradle.kts
@@ -67,10 +67,6 @@ kotlin {
     all {
       languageSettings.optIn("kotlin.contracts.ExperimentalContracts")
     }
-    val commonMain by getting {
-      dependencies {
-      }
-    }
   }
 
   explicitApi()


### PR DESCRIPTION
Migrate to Stream Log 1.3.0 and support stream-result-call for KMP.