### PR TITLE
Target JVM 11 bytecode instead of 17

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,8 +36,8 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
   }
 
   lint {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ apiValidation {
 
 subprojects {
   tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_17.toString()
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
   }
 
   apply(plugin = rootProject.libs.plugins.spotless.get().pluginId)

--- a/stream-result-call-retrofit/build.gradle.kts
+++ b/stream-result-call-retrofit/build.gradle.kts
@@ -57,8 +57,8 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
   }
 
 }

--- a/stream-result-call/build.gradle.kts
+++ b/stream-result-call/build.gradle.kts
@@ -105,8 +105,8 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
   }
 }
  dependencies {

--- a/stream-result/build.gradle.kts
+++ b/stream-result/build.gradle.kts
@@ -93,8 +93,8 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
   }
 }
 


### PR DESCRIPTION
Fixes [AND-1372](https://linear.app/stream/issue/AND-1372/stream-result-target-jvm-11-bytecode-instead-of-17)

### 🎯 Goal
stream-result has emitted JVM 17 bytecode since 1.3.3 (the 2024-09-30 "Use Java Version 17" sweep). Kotlin can't inline JVM-17 `inline` functions (`Result.map`/`flatMap`, `Error` helpers) into a JVM-11 compilation, so JVM-11 consumers fail to compile — blocking stream-chat-android on any bump past 1.3.2 (surfaced wiring the AND-1367 bump to 1.4.0).

Every Stream product SDK is JVM 11 — Chat, Core, Feeds, and Video (the released `stream-video-android-core-1.29.0.aar` is Java 11 bytecode) — and nothing ever consumed the JVM-17 builds, so lowering the target realigns stream-result with all of its consumers.

### 🛠 Implementation details
- Revert `sourceCompatibility`/`targetCompatibility` and `kotlinOptions.jvmTarget` from `17` back to `11` across all modules (`build.gradle.kts`, `stream-result`, `stream-result-call`, `stream-result-call-retrofit`, `app`).
- JDK 17 build toolchain unchanged — only the emitted bytecode target is lowered. 11 is the compatible floor: JVM-17 consumers can still use an 11 library.
- No source changes; stream-result is `commonMain` KMP with zero dependencies, so nothing requires Java 17.
- Version is not bumped here (release-owned); the next release carries this plus the `GenericError.code` slot already on develop.

### 🧪 Testing
- `./gradlew apiCheck spotlessCheck` pass across all modules.
- Verified the emitted bytecode: compiled `Error.class` is class major version **55 (Java 11)** — was 61 (Java 17) in 1.4.0.

### ☑️Contributor Checklist
#### General
- [ ] I have signed the Stream CLA (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required)